### PR TITLE
Actualización modelo 06062024

### DIFF
--- a/public/normas_captura/0301p_extrac_material.vue
+++ b/public/normas_captura/0301p_extrac_material.vue
@@ -6,6 +6,14 @@
 		Además, el <b>atributo sustancia</b> es obligatorio siempre que la instalación ocupe una <b>superficie mayor de 5Ha</b>. 
 		En caso contrario, se admite el valor -97 (desconocido).</p> 
 
+		<p>Las explotaciones mineras <b>no se eliminan</b> mientras: <ol>
+			<li>Queden marcas perceptibles en el terreno asociadas a la actividad extractiva.</li>
+			<li>Se trate de explotaciones históricas o con valor paisajístico.</li>
+		</ol>
+			Hay que tener <b>precaución en no eliminar antiguas explotaciones recuperadas paisajísticamente</b> y reconvertidas en espacios naturales, parques, etc. 
+			En estos casos coexisten la explotación minera y el objeto con el nuevo uso, un jardín, por ejemplo.
+		</p> 
+
 		<p>En el caso de las explotaciones subterráneas, la geometría puntual puede indicar tanto la <b>boca de entrada</b> a una galería subterránea 
 			como la <b>posición representativa</b> de toda la explotación o todo el conjunto de pozos y galerías.</p>
 
@@ -19,11 +27,15 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> de Extracción de materiales <strong>asociadas</strong> a la entidad puntual (ver objeto 0301z). 
-			La asociación de las zonas al punto se recoge en el atributo <strong>“id_extract”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, 
-			esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> de Extracción de materiales <b>asociadas</b> a la entidad puntual (ver objeto 0301z).
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+	
 
-		<p>Aunque para el <strong>atributo sustancia</strong> hay una lista de valores, no es una lista cerrada. Además, 
-			si se realiza la extracción de más de un tipo de sustancia, se deben concatenar varios valores separados por comas. </p>
+		<p>Aunque para el <b>atributo sustancia</b> hay una lista de valores, no es una lista cerrada. Además, 
+		si se realiza la extracción de más de un tipo de sustancia, se deben concatenar varios valores separados por comas. </p>
+
+		<p>El modelo de datos <b>no contempla</b> si la instalación se encuentra <b>prestando servicio</b> en la actualidad o por el contrario está <b>cerrada de forma temporal o permanente</b>. 
+			Como norma general la entidad se mantiene mientras existan restos visibles, aunque ruinosos, de las instalaciones, especialmente cuando tienen carácter histórico.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0301z_extrac_material.vue
+++ b/public/normas_captura/0301z_extrac_material.vue
@@ -1,13 +1,13 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico se capturan <strong>como elementos superficiales</strong> definidos por el borde o contorno exterior de la explotación en <strong>sentido horario.</strong></p>
+		<p>Las entidades que se recogen para este objeto geográfico se capturan <b>como elementos superficiales</b> definidos por el borde o contorno exterior de la explotación en <b>sentido horario.</b></p>
 
-		<p>En el <strong>caso de una explotación superficial</strong>, si el perímetro está <strong>delimitado</strong> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la explotación minera. En caso de <strong>no tener una delimitación</strong> física en el terreno se representan los límites externos imaginarios de estas zonas.</p>
+		<p>En el <b>caso de una explotación superficial</b>, si el perímetro está <b>delimitado</b> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la explotación minera. En caso de <b>no tener una delimitación</b> física en el terreno se representan los límites externos imaginarios de estas zonas.</p>
 
-		<p>En su <strong>interior</strong> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
+		<p>En su <b>interior</b> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
 
-		<p>En los casos de <strong>explotaciones a cielo abierto</strong> en el punto o puntos de menor cota se dará un punto de depresión, dejando cortados los caminos de acceso e interiores a la explotación si se aprecia que no son permanentes.</p>
+		<p>En los casos de <b>explotaciones a cielo abierto</b> en el punto o puntos de menor cota se dará un punto de depresión, dejando cortados los caminos de acceso e interiores a la explotación si se aprecia que no son permanentes.</p>
 
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
@@ -19,6 +19,8 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>La <strong>zona de Extracción de materiales</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0301p). Puede haber varias zonas asociadas al mismo punto. La asociación de las zonas al punto se recoge en el atributo <strong>“id_extract”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una <strong>relationship class</strong>, empleando otros atributos internos).</p>
+		<p>La <b>zona de Extracción de materiales</b> debe estar asociada a una <b>entidad puntual</b> (ver objeto 0301p). 
+		Puede haber varias zonas asociadas al mismo punto. 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.</p>
 	</div>
 </template>

--- a/public/normas_captura/0304p_agropec_salina_pisci.vue
+++ b/public/normas_captura/0304p_agropec_salina_pisci.vue
@@ -43,6 +43,8 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> Agropecuarias, salinas y pisciculturas <strong>asociadas</strong> a la entidad puntual (ver objeto 0304z). La asociación de las zonas al punto se recoge en el atributo <strong>“id_agsapi”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> Agropecuarias, salinas y pisciculturas <b>asociadas</b> a la entidad puntual (ver objeto 0304z). 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0304z_agropec_salina_pisci.vue
+++ b/public/normas_captura/0304z_agropec_salina_pisci.vue
@@ -18,6 +18,9 @@
 		<p>No se han definido criterios de selección para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>La <strong>zona agropecuaria, salina y piscifactoria</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0304p). Puede haber varias zonas asociadas al mismo punto. La asociación de las zonas al punto se recoge en el atributo “id_agsapi” (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>La <strong>zona agropecuaria, salina y piscifactoria</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0304p). 
+		Puede haber varias zonas asociadas al mismo punto. 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0307p_energia.vue
+++ b/public/normas_captura/0307p_energia.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico son <strong>elementos puntuales indicativos del lugar</strong> donde se encuentra la instalación o el servicio. Se debe <strong>especificar siempre el valor del atributo tipo</strong> (tipo_0307p).</p>
+		<p>Las entidades que se recogen para este objeto geográfico son <b>elementos puntuales indicativos del lugar</b> donde se encuentra la instalación o el servicio. Se debe <b>especificar siempre el valor del atributo tipo</b> (tipo_0307p).</p>
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">	
 			<img src="../img/0307z_energia_1.png">
@@ -15,6 +15,8 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> de Energía <strong>asociadas</strong> a la entidad puntual (ver objeto 0307z). La asociación de las zonas al punto se recoge en el atributo <strong>“id_ener”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> de Energía <b>asociadas</b> a la entidad puntual (ver objeto 0307z).
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p> 
 	</div>
 </template>

--- a/public/normas_captura/0307z_energia.vue
+++ b/public/normas_captura/0307z_energia.vue
@@ -1,13 +1,13 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico se capturan <strong>como elementos superficiales</strong> definidos por el borde o contorno exterior de la zona en <strong>sentido horario.</strong></p>
+		<p>Las entidades que se recogen para este objeto geográfico se capturan <b>como elementos superficiales</b> definidos por el borde o contorno exterior de la zona en <b>sentido horario.</b></p>
 
-		<p>Si el perímetro está <strong>delimitado</strong> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona energía. En caso de <strong>no tener una delimitación física</strong> en el terreno se representan los límites externos imaginarios de estas zonas.</p>
+		<p>Si el perímetro está <b>delimitado</b> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona energía. En caso de <b>no tener una delimitación física</b> en el terreno se representan los límites externos imaginarios de estas zonas.</p>
 
-		<p>En su <strong>interior</strong> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
+		<p>En su <b>interior</b> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">	
 			<img src="../img/0307z_energia_1.png">
@@ -18,6 +18,9 @@
 		<p>No se han definido criterios de selección para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>La <strong>zona de Energía</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0307p). Puede haber varias zonas asociadas al mismo punto. La asociación de las zonas al punto se recoge en el atributo <strong>“id_ener”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una <strong>relationship class</strong>, empleando otros atributos internos).</p>
+		<p>La <b>zona de Energía</b> debe estar asociada a una <b>entidad puntual</b> (ver objeto 0307p). 
+		Puede haber varias zonas asociadas al mismo punto.
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0310p_industria_serv_com.vue
+++ b/public/normas_captura/0310p_industria_serv_com.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico son <strong>elementos puntuales indicativos del lugar</strong> donde se encuentra la instalación o el servicio. Se debe <strong>especificar siempre el valor del atributo tipo</strong> (tipo_0310p).</p> 
+		<p>Las entidades que se recogen para este objeto geográfico son <b>elementos puntuales indicativos del lugar</b> donde se encuentra la instalación o el servicio. Se debe <b>especificar siempre el valor del atributo tipo</b> (tipo_0310p).</p> 
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
 			<i>
@@ -16,6 +16,8 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> de Industria, servicio y comercio <strong>asociadas</strong> a la entidad puntual (ver objeto 0310z). La asociación de las zonas al punto se recoge en el atributo <strong>“id_inseco”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> de Industria, servicio y comercio <b>asociadas</b> a la entidad puntual (ver objeto 0310z).
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0310z_industria_serv_com.vue
+++ b/public/normas_captura/0310z_industria_serv_com.vue
@@ -1,13 +1,13 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico se capturan <strong>como elementos superficiales</strong> definidos por el borde o contorno exterior de la zona en <strong>sentido horario.</strong></p>
+		<p>Las entidades que se recogen para este objeto geográfico se capturan <b>como elementos superficiales</b> definidos por el borde o contorno exterior de la zona en <b>sentido horario.</b></p>
 
-		<p>Si el perímetro está <strong>delimitado</strong> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona de tratamiento de agua y residuos. En caso de <strong>no tener una delimitación física</strong> en el terreno, se representan los límites externos imaginarios de estas zonas.</p>
+		<p>Si el perímetro está <b>delimitado</b> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona de tratamiento de agua y residuos. En caso de <b>no tener una delimitación física</b> en el terreno, se representan los límites externos imaginarios de estas zonas.</p>
 
-		<p>En su <strong>interior</strong> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
+		<p>En su <b>interior</b> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
 			<i>
@@ -20,6 +20,9 @@
 		<p>No se han definido criterios de selección para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>La <strong>zona de Industria, servicio y comercio</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0310p). Puede haber varias zonas asociadas al mismo punto. La asociación de las zonas al punto se recoge en el atributo <strong>“id_inseco”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una <strong>relationship class</strong>, empleando otros atributos internos).</p>
+		<p>La <b>zona de Industria, servicio y comercio</b> debe estar asociada a una <b>entidad puntual</b> (ver objeto 0310p). 
+		Puede haber varias zonas asociadas al mismo punto. 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0313p_admon_equip_social.vue
+++ b/public/normas_captura/0313p_admon_equip_social.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico son <strong>elementos puntuales indicativos del lugar</strong> donde se encuentra la instalación o el servicio. Se debe <strong>especificar siempre el valor del atributo tipo</strong> (tipo_0313p).</p> 
+		<p>Las entidades que se recogen para este objeto geográfico son <b>elementos puntuales indicativos del lugar</b> donde se encuentra la instalación o el servicio. Se debe <b>especificar siempre el valor del atributo tipo</b> (tipo_0313p).</p> 
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
 				<i>
@@ -16,32 +16,34 @@
 		<p>No se han definido criterios de selección para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> de Administración equipamiento social <strong>asociadas</strong> a la entidad puntual (ver objeto 0301z). La asociación de las zonas al punto se recoge en el atributo <strong>“id_adeqso”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> de Administración equipamiento social <b>asociadas</b> a la entidad puntual (ver objeto 0301z). 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.	
+		</p>
 
 		<h3>SUPRAEQUIPAMIENTO</h3>
-		<p>En determinados casos podemos encontrar <strong>construcciones que, aun estando separadas</strong> por varios kilómetros e incluso en provincias diferentes, forman parte de un mismo complejo.</p>
+		<p>En determinados casos podemos encontrar <b>construcciones que, aun estando separadas</b> por varios kilómetros e incluso en provincias diferentes, forman parte de un mismo complejo.</p>
 
-		<p><strong>Por ejemplo</strong>, podemos encontrar varios centros hospitalarios en una misma ciudad que, aunque formen parte del mismo complejo hospitalario, no comparten una ubicación. Un centro hospitalario puede tener uno o varios edificios.</p>
+		<p><b>Por ejemplo</b>, podemos encontrar varios centros hospitalarios en una misma ciudad que, aunque formen parte del mismo complejo hospitalario, no comparten una ubicación. Un centro hospitalario puede tener uno o varios edificios.</p>
 
 			<blockquote>
 				<h4>Caso práctico - Hospital Universitario Reina Sófia (Córboba)</h4>
 				<p>Este supraequipamiento lo forman 5 complejos hospitalarios, de los cuales:</p>
 					<ol>
-						<li>El centro <strong>"padre"</strong> Es el Hospital Universitario Reina Sofia, ubicado en la Avda. Menéndez Pidal s/n.</li>
+						<li>El centro <b>"padre"</b> Es el Hospital Universitario Reina Sofia, ubicado en la Avda. Menéndez Pidal s/n.</li>
 						<li>Hospital Materno - Infantil del H.U. Reina Sofía, ubicado en la Avda. Menéndez Pidal s/n. Es un centro "hijo"</li>
 						<li>Hospital Provincial, ubicado en la Avda. Menéndez Pidal s/n. Es un centro "hijo"</li>
 						<li>Hospital General de H.U Reina Sofía, ubicado en la Avda. Menéndez Pidal s/n. Es un centro "hijo"</li>
 						<li>Hospital Los Morales, ubicado en la ctra. de los Morales s/n.</li>
 					</ol>
 
-				<p>Como podemos ver tenemos cuatro hospitales formando un complejo en la Avda. Menéndez Pidal s/n y un completo hospitalario (de un solo hospital) ubicado en la ctra. de los Morales. No obstante todos forman parte del Supraequipamiento <strong>Hospital Universitario Reina Sofia</strong></p>
+				<p>Como podemos ver tenemos cuatro hospitales formando un complejo en la Avda. Menéndez Pidal s/n y un completo hospitalario (de un solo hospital) ubicado en la ctra. de los Morales. No obstante todos forman parte del Supraequipamiento <b>Hospital Universitario Reina Sofia</b></p>
 				<i>Información procedente del Catálogo de Hospitales del Ministerio de Sanidad y Consumo 2020</i>
 			</blockquote>
 
 
 		<p>En estos casos hablamos de que existe un SUPRAEQUIPAMIENTO. Ya que un centro hospitalario actúa como “sede central” (padre) y uno o varios centros que actúan como “sedes” (hijos). El “padre” es un SUPRAEQUIPAMIENTO de los hijos.</p>
 
-		<p><strong>Para vincular estos centros “hijos” al “padre” los atributos han de completarse de este modo: </strong></p>
+		<p><b>Para vincular estos centros “hijos” al “padre” los atributos han de completarse de este modo: </b></p>
 
 		<h3><i>Ejemplo:</i></h3>
 		<ul>
@@ -63,11 +65,11 @@
 			<li>El atributo id_adeqso debe ser el mismo para los elementos 0313z y 0313p</li>
 		</ul>
 
-		<p>En el caso que de los <strong>complejos hospitalarios formados solo por un centro hospitalario</strong>, los atributos “supr_0313p” y “cod_supra” deben ser “NO” y “NULL” respectivamente.</p>
+		<p>En el caso que de los <b>complejos hospitalarios formados solo por un centro hospitalario</b>, los atributos “supr_0313p” y “cod_supra” deben ser “NO” y “NULL” respectivamente.</p>
 
 		<p>El resto de atributos de los elementos deben completarse de acuerdo a sus normas específicas. </p>
 
-		<p>Además del ejemplo empleado para el caso de los hospitales, podemos encontrar <strong>otros ejemplos de supraequipamientos</strong> en las universidades, estas pueden tener varios campus ubicados en zonas diferentes aunque todos ellos formen parte de la misma universidad.</p>
+		<p>Además del ejemplo empleado para el caso de los hospitales, podemos encontrar <b>otros ejemplos de supraequipamientos</b> en las universidades, estas pueden tener varios campus ubicados en zonas diferentes aunque todos ellos formen parte de la misma universidad.</p>
 
 		<p>Por ello el atributo supraequipamiento debe emplearse en todos los casos en los que sea aplicable el razonamiento expuesto anteriormente.</p>
 	</div>

--- a/public/normas_captura/0313z_admon_equip_social.vue
+++ b/public/normas_captura/0313z_admon_equip_social.vue
@@ -1,13 +1,13 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico se capturan <strong>como elementos superficiales</strong> definidos por el borde o contorno exterior de la zona en <strong>sentido horario.</strong></p>
+		<p>Las entidades que se recogen para este objeto geográfico se capturan <b>como elementos superficiales</b> definidos por el borde o contorno exterior de la zona en <b>sentido horario.</b></p>
 
-		<p>Si el perímetro está <strong>delimitado</strong> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona de Administración equipamiento social. En caso de <strong>no tener una delimitación</strong> física en el terreno se representan los límites externos imaginarios de estas zonas.</p>
+		<p>Si el perímetro está <b>delimitado</b> por tapias, muros o alambradas deben duplicarse éstos hasta formar el perímetro de la zona de Administración equipamiento social. En caso de <b>no tener una delimitación</b> física en el terreno se representan los límites externos imaginarios de estas zonas.</p>
 
-		<p>En su <strong>interior</strong> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
+		<p>En su <b>interior</b> se ubican las entidades (naves, edificios, estanques, depósitos, etc.) estas siguen las normas de captura específicas definidas para ellas.</p>
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
 				<i>
@@ -20,6 +20,9 @@
 		<p>No se han definido criterios de selección para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>La <strong>zona de Administración equipamiento social</strong> debe estar asociada a una <strong>entidad puntual</strong> (ver objeto 0313p). Puede haber varias zonas asociadas al mismo punto. La asociación de las zonas al punto se recoge en el atributo <strong>“id_adeqso”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una <strong>relationship class</strong>, empleando otros atributos internos).</p>
+		<p>La <b>zona de Administración equipamiento social</b> debe estar asociada a una <b>entidad puntual</b> (ver objeto 0313p). 
+		Puede haber varias zonas asociadas al mismo punto. 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0316p_cultura_ocio.vue
+++ b/public/normas_captura/0316p_cultura_ocio.vue
@@ -1,11 +1,11 @@
 <template>
 	<div>
 		<h2>Normas de captura</h2>
-		<p>Las entidades que se recogen para este objeto geográfico son <strong>elementos puntuales indicativos del lugar</strong> donde se encuentra la instalación o el servicio. Se debe <strong>especificar siempre el valor del atributo tipo</strong> (tipo_0316p).</p> 
+		<p>Las entidades que se recogen para este objeto geográfico son <b>elementos puntuales indicativos del lugar</b> donde se encuentra la instalación o el servicio. Se debe <b>especificar siempre el valor del atributo tipo</b> (tipo_0316p).</p> 
 
-		<p>Los parques infantiles <strong>no se capturan</strong>, salvo que sean ajardinados y puedan ser considerados un jardín o parque tal y como se definen en el valor <strong>Parque - jardín</strong>.</p>
+		<p>Los parques infantiles <b>no se capturan</b>, salvo que sean ajardinados y puedan ser considerados un jardín o parque tal y como se definen en el valor <b>Parque - jardín</b>.</p>
 
-		<p>El modelo de datos <strong>no contempla</strong> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
+		<p>El modelo de datos <b>no contempla</b> el estado de uso o conservación de las instalaciones o servicios. Como norma general, la entidad no se captura cuando el servicio ya no se presta de manera definitiva y/o cuando las instalaciones están totalmente deterioradas o han desaparecido, a excepción de entidades con carácter histórico.</p>
 		<h3>Ejemplo de captura</h3>
 		<div class="picture">
 			
@@ -17,6 +17,8 @@
 		<p>No se han definido criterios de selección específicos para este objeto.</p>
 
 		<h2>Notas</h2>
-		<p>Puede haber <strong>una o varias zonas</strong> de Cultura y ocio <strong>asociadas</strong> a la entidad puntual (ver objeto 0316z). La asociación de las zonas al punto se recoge en el atributo <strong>“id_ocio”</strong> (no obstante, en los trabajos de captura mediante el entorno de actualización, esta relación se materializa mediante una relationship class, empleando otros atributos internos).</p>
+		<p>Puede haber <b>una o varias zonas</b> de Cultura y ocio <b>asociadas</b> a la entidad puntual (ver objeto 0316z). 
+		Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
+		</p>
 	</div>
 </template>

--- a/public/normas_captura/0316z_cultura_ocio.vue
+++ b/public/normas_captura/0316z_cultura_ocio.vue
@@ -3,26 +3,26 @@
     <h2>Normas de captura</h2>
     <p>
       Las entidades que se recogen para este objeto geográfico se capturan
-      <strong>como elementos superficiales</strong> definidos por el borde o
-      contorno exterior de la zona en <strong>sentido horario.</strong>
+      <b>como elementos superficiales</b> definidos por el borde o
+      contorno exterior de la zona en <b>sentido horario.</b>
     </p>
 
     <p>
-      Si el perímetro está <strong>delimitado</strong> por tapias, muros o
+      Si el perímetro está <b>delimitado</b> por tapias, muros o
       alambradas deben duplicarse éstos hasta formar el perímetro de la zona de
       cultura y ocio. En caso de
-      <strong>no tener una delimitación</strong> física en el terreno se
+      <b>no tener una delimitación</b> física en el terreno se
       representan los límites externos imaginarios de estas zonas.
     </p>
 
     <p>
-      En su <strong>interior</strong> se ubican las entidades (naves, edificios,
+      En su <b>interior</b> se ubican las entidades (naves, edificios,
       estanques, depósitos, etc.) estas siguen las normas de captura específicas
       definidas para ellas.
     </p>
 
     <p>
-      El modelo de datos <strong>no contempla</strong> el estado de uso o
+      El modelo de datos <b>no contempla</b> el estado de uso o
       conservación de las instalaciones o servicios. Como norma general, la
       entidad no se captura cuando el servicio ya no se presta de manera
       definitiva y/o cuando las instalaciones están totalmente deterioradas o
@@ -44,13 +44,10 @@
 
     <h2>Notas</h2>
     <p>
-      La <strong>zona de Cultura y ocio</strong> debe estar asociada a una
-      <strong>entidad puntual</strong> (ver objeto 0316p). Puede haber varias
-      zonas asociadas al mismo punto. La asociación de las zonas al punto se
-      recoge en el atributo <strong>“id_ocio”</strong> (no obstante, en los
-      trabajos de captura mediante el entorno de actualización, esta relación se
-      materializa mediante una <strong>relationship class</strong>, empleando
-      otros atributos internos).
+      La <b>zona de Cultura y ocio</b> debe estar asociada a una
+      <b>entidad puntual</b> (ver objeto 0316p). Puede haber varias
+      zonas asociadas al mismo punto. 
+      Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
     </p>
   </div>
 </template>

--- a/public/normas_captura/0319p_trat_agua_residuos.vue
+++ b/public/normas_captura/0319p_trat_agua_residuos.vue
@@ -3,14 +3,14 @@
     <h2>Normas de captura</h2>
     <p>
       Las entidades que se recogen para este objeto geográfico son
-      <strong>elementos puntuales indicativos del lugar</strong> donde se
+      <b>elementos puntuales indicativos del lugar</b> donde se
       encuentra la instalación o el servicio. Se debe
-      <strong>especificar siempre el valor del atributo tipo</strong>
+      <b>especificar siempre el valor del atributo tipo</b>
       (tipo_0319p).
     </p>
 
     <p>
-      El modelo de datos <strong>no contempla</strong> el estado de uso o
+      El modelo de datos <b>no contempla</b> el estado de uso o
       conservación de las instalaciones o servicios. Como norma general, la
       entidad no se captura cuando el servicio ya no se presta de manera
       definitiva y/o cuando las instalaciones están totalmente deterioradas o
@@ -37,12 +37,9 @@
 
     <h2>Notas</h2>
     <p>
-      Puede haber <strong>una o varias zonas</strong> de Tratamiento de agua y
-      residuos<strong>asociadas</strong> a la entidad puntual (ver objeto
-      0319z). La asociación de las zonas al punto se recoge en el atributo
-      <strong>“id_tagures”</strong> (no obstante, en los trabajos de captura
-      mediante el entorno de actualización, esta relación se materializa
-      mediante una relationship class, empleando otros atributos internos).
+      Puede haber <b>una o varias zonas</b> de Tratamiento de agua y
+      residuos<b>asociadas</b> a la entidad puntual (ver objeto
+      0319z). Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
     </p>
   </div>
 </template>

--- a/public/normas_captura/0319z_trat_agua_residuos.vue
+++ b/public/normas_captura/0319z_trat_agua_residuos.vue
@@ -3,26 +3,26 @@
     <h2>Normas de captura</h2>
     <p>
       Las entidades que se recogen para este objeto geográfico se capturan
-      <strong>como elementos superficiales</strong> definidos por el borde o
-      contorno exterior de la zona en <strong>sentido horario.</strong>
+      <b>como elementos superficiales</b> definidos por el borde o
+      contorno exterior de la zona en <b>sentido horario.</b>
     </p>
 
     <p>
-      Si el perímetro está <strong>delimitado</strong> por tapias, muros o
+      Si el perímetro está <b>delimitado</b> por tapias, muros o
       alambradas deben duplicarse éstos hasta formar el perímetro de la zona de
       tratamiento de agua y residuos. En caso de
-      <strong>no tener una delimitación</strong> física en el terreno se
+      <b>no tener una delimitación</b> física en el terreno se
       representan los límites externos imaginarios de estas zonas.
     </p>
 
     <p>
-      En su <strong>interior</strong> se ubican las entidades (naves, edificios,
+      En su <b>interior</b> se ubican las entidades (naves, edificios,
       estanques, depósitos, etc.) estas siguen las normas de captura específicas
       definidas para ellas.
     </p>
 
     <p>
-      El modelo de datos <strong>no contempla</strong> el estado de uso o
+      El modelo de datos <b>no contempla</b> el estado de uso o
       conservación de las instalaciones o servicios. Como norma general, la
       entidad no se captura cuando el servicio ya no se presta de manera
       definitiva y/o cuando las instalaciones están totalmente deterioradas o
@@ -41,13 +41,9 @@
 
     <h2>Notas</h2>
     <p>
-      La <strong>zona de Tratamiento de agua y residuos</strong> debe estar
-      asociada a una <strong>entidad puntual</strong> (ver objeto 0319p). Puede
-      haber varias zonas asociadas al mismo punto. La asociación de las zonas al
-      punto se recoge en el atributo <strong>“id_tagures”</strong> (no obstante,
-      en los trabajos de captura mediante el entorno de actualización, esta
-      relación se materializa mediante una <strong>relationship class</strong>,
-      empleando otros atributos internos).
+      La <b>zona de Tratamiento de agua y residuos</b> debe estar
+      asociada a una <b>entidad puntual</b> (ver objeto 0319p). Puede
+      haber varias zonas asociadas al mismo punto. Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
     </p>
   </div>
 </template>

--- a/public/normas_captura/0322p_otros_serv_inst.vue
+++ b/public/normas_captura/0322p_otros_serv_inst.vue
@@ -3,14 +3,13 @@
     <h2>Normas de captura</h2>
     <p>
       Las entidades que se recogen para este objeto geográfico son
-      <strong>elementos puntuales indicativos del lugar</strong> donde se
+      <b>elementos puntuales indicativos del lugar</b> donde se
       encuentra la instalación o el servicio. Se debe
-      <strong>especificar siempre el valor del atributo tipo</strong
-      >(tipo_0322p).
+      <b>especificar siempre el valor del atributo tipo</b>(tipo_0322p).
     </p>
 
     <p>
-      El modelo de datos <strong>no contempla</strong> el estado de uso o
+      El modelo de datos <b>no contempla</b> el estado de uso o
       conservación de las instalaciones o servicios. Como norma general, la
       entidad no se captura cuando el servicio ya no se presta de manera
       definitiva y/o cuando las instalaciones están totalmente deterioradas o
@@ -34,12 +33,9 @@
 
     <h2>Notas</h2>
     <p>
-      Puede haber <strong>una o varias zonas</strong> de Otros servicios e
-      instalaciones<strong>asociadas</strong> a la entidad puntual (ver objeto
-      0322z). La asociación de las zonas al punto se recoge en el atributo
-      <strong>“id_instal”</strong> (no obstante, en los trabajos de captura
-      mediante el entorno de actualización, esta relación se materializa
-      mediante una relationship class, empleando otros atributos internos).
+      Puede haber <b>una o varias zonas</b> de Otros servicios e
+      instalaciones<b>asociadas</b> a la entidad puntual (ver objeto
+      0322z). Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
     </p>
   </div>
 </template>

--- a/public/normas_captura/0322z_otros_serv_inst.vue
+++ b/public/normas_captura/0322z_otros_serv_inst.vue
@@ -3,15 +3,15 @@
     <h2>Normas de captura</h2>
     <p>
       Las entidades que se recogen para este objeto geográfico se capturan
-      <strong>como elementos superficiales</strong> definidos por el borde o
-      contorno exterior de la zona en <strong>sentido horario.</strong>
+      <b>como elementos superficiales</b> definidos por el borde o
+      contorno exterior de la zona en <b>sentido horario.</b>
     </p>
 
     <p>
-      Si el perímetro está <strong>delimitado</strong> por tapias, muros o
+      Si el perímetro está <b>delimitado</b> por tapias, muros o
       alambradas deben duplicarse éstos hasta formar el perímetro de la zona de
       otros servicios e instalaciones. En caso de
-      <strong>no tener una delimitación</strong> física en el terreno se
+      <b>no tener una delimitación</b> física en el terreno se
       representan los límites externos imaginarios de estas zonas.
     </p>
 
@@ -22,7 +22,7 @@
     </p>
 
     <p>
-      El modelo de datos <strong>no contempla</strong> el estado de uso o
+      El modelo de datos <b>no contempla</b> el estado de uso o
       conservación de las instalaciones o servicios. Como norma general, la
       entidad no se captura cuando el servicio ya no se presta de manera
       definitiva y/o cuando las instalaciones están totalmente deterioradas o
@@ -44,13 +44,9 @@
 
     <h2>Notas</h2>
     <p>
-      La <strong>zona de Otros servicios e instalaciones</strong> debe estar
-      asociada a una <strong>entidad puntual</strong> (ver objeto 0322p). Puede
-      haber varias zonas asociadas al mismo punto. La asociación de las zonas al
-      punto se recoge en el atributo <strong>“id_instal”</strong> (no obstante,
-      en los trabajos de captura mediante el entorno de actualización, esta
-      relación se materializa mediante una <strong>relationship class</strong>,
-      empleando otros atributos internos).
+      La <b>zona de Otros servicios e instalaciones</b> debe estar
+      asociada a una <b>entidad puntual</b> (ver objeto 0322p). Puede
+      haber varias zonas asociadas al mismo punto. Esta asociación se realiza mediante el atributo <b>globalid</b> del puntual y el <b>guid_p</b> de la zona.
     </p>
   </div>
 </template>

--- a/src/assets/mixins/classifyGroupBTN.js
+++ b/src/assets/mixins/classifyGroupBTN.js
@@ -1,54 +1,46 @@
 export const classifyGroupBTN = {
+    data(){
+        return {
+            itemsBTN: []
+        }
+    },
+
     methods: {
-        classifyGroupBTN(objetos){
-            let itemsBTN = [
-                {
-                    group: 'Transportes',
-                    icon: this.getGroupBtnIcon('01'),
+        createTheme(groupName, codigo){
+            let newGroup = {
+                    group: groupName,
+                    icon: this.getGroupBtnIcon(codigo),
                     values: []
-                },
-                {
-                    group: 'Edificios y construcciones',
-                    icon: this.getGroupBtnIcon('02'), 
-                    values: []
-                }, 
-                {
-                    group: 'Servicios e instalaciones',
-                    icon: this.getGroupBtnIcon('03'), 
-                    values: []
-                }, 
-                {
-                    group: 'Hidrografía',
-                    icon: this.getGroupBtnIcon('04'), 
-                    values: []
-                },
-                {
-                    group: 'Orografía y paisaje',
-                    icon: this.getGroupBtnIcon('05'), 
-                    values: []
-                },  
-                {
-                    group: 'Zonas administrativas',
-                    icon: this.getGroupBtnIcon('07'), 
-                    values: []
-                }, 
-            ];
-
-            
-            // INDICE OBJETOS
-            for (this.index in objetos){
-                let newObject = {
-                    code: this.btnObjects[this.index].codigo, 
-                    title: this.btnObjects[this.index].nom_corto, 
-                    active: {
-                        esquema: 'BTN',
-                        codigo: this.btnObjects[this.index].codigo,
-                    }
                 }
-                itemsBTN[itemsBTN.map((item)=>item.group).indexOf(objetos[this.index].nombre_tema)].values.push(newObject)               
-            }
+            return newGroup
+        },
 
-            return itemsBTN;
+        createObject(objeto){
+            let newObject = {
+                code: objeto.codigo, 
+                title: objeto.nom_corto, 
+                active: {
+                    esquema: 'BTN',
+                    codigo: objeto.codigo,
+                }
+            }
+            return newObject
+        },
+
+        classifyGroupBTN(objetos){
+            objetos.forEach((objeto)=>{
+                if(this.itemsBTN.map((item)=>item.group).includes(objeto.nombre_tema)){
+                    //SI TENEMOS EL TEMA INSERTAMOS OBJETO
+                    this.itemsBTN[this.itemsBTN.map((item)=>item.group).indexOf(objeto.nombre_tema)].values.push(this.createObject(objeto))
+                   
+                } else {
+                    //CREAMOS EL TEMA EN EL INDICE Y LUEGO INSERTAMOS
+                    this.itemsBTN.push(this.createTheme(objeto.nombre_tema, objeto.codigo))
+                    this.itemsBTN[this.itemsBTN.map((item)=>item.group).indexOf(objeto.nombre_tema)].values.push(this.createObject(objeto))
+                }
+            })
+
+            return this.itemsBTN
             }
         }
     }  

--- a/src/assets/mixins/getGroupBtnIcon.js
+++ b/src/assets/mixins/getGroupBtnIcon.js
@@ -25,6 +25,10 @@ export const getGroupBtnIcon = {
             else if (codigo.charAt(1) == 7){
                 return 'mdi-pine-tree'
             }
+            //ZONAS ADMIN
+            else if (codigo.charAt(1) == 9){
+                return 'mdi-group'
+            }
 
             else {
                 console.log("getGroupIcon error, no encontrado codigo ->", codigo)

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -128,7 +128,7 @@
                             </div>
                             <div v-else>
                                 {{attribute.definicion}}
-                                <div class="subTableContainer">
+                                <div class="subTableContainer" v-if="attribute.tipo_valor === 'lista_val'">
                                     <h4 class="valuesTitle">VALORES</h4>
                                     <v-simple-table class="subTable">
                                         <tbody>
@@ -428,6 +428,7 @@ export default {
                 axios
                 .get(this.apiRoute + `/api/v1/${object.esquema}/attributes`)
                 .then((data) => {
+                    console.log(data)
                     this.objeto = undefined;
                     this.atributosComunes = {
                         esquema: object.esquema,

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -139,6 +139,7 @@
             },
             
             initialize(){
+                this.items = []
                 this.checkActiveSchema()
             },
 
@@ -168,33 +169,36 @@
 
             //BDIG de momento es igual que BTN
             async getBDIGObjects(){
-                this.items = [];
-                axios
-                .get(this.apiRoute + '/api/v1/bdig/objects')
-                .then ((data) => {
-                    this.btnObjects = data.data.resultados;
-                    this.items = this.classifyGroupBTN(this.btnObjects);
-                })
+                if(this.items.length === 0){
+                    axios
+                    .get(this.apiRoute + '/api/v1/bdig/objects')
+                    .then ((data) => {
+                        this.btnObjects = data.data.resultados;
+                        this.items = this.classifyGroupBTN(this.btnObjects);
+                    })
+                }
             },
 
             async getBtnObjects(){
-                this.items = [];
-                axios
-                .get(this.apiRoute + '/api/v1/btn/objects')
-                .then ((data) => {
-                    this.btnObjects = data.data.resultados;
-                    this.items = this.classifyGroupBTN(this.btnObjects);
-                })
+                if(this.items.length === 0){
+                    axios
+                    .get(this.apiRoute + '/api/v1/btn/objects')
+                    .then ((data) => {
+                        this.btnObjects = data.data.resultados;
+                        this.items = this.classifyGroupBTN(this.btnObjects);
+                    })
+                }
             },
 
             async getRtObjects(){
-                this.items = [];
-                axios
-                .get(this.apiRoute + '/api/v1/rt/objects')
-                .then ((data) => {
-                    this.rtObjects = data.data.resultados;
-                    this.items = this.classifyGroupRT(this.rtObjects);
-                })
+                if(this.items.length === 0){
+                    axios
+                    .get(this.apiRoute + '/api/v1/rt/objects')
+                    .then ((data) => {
+                        this.rtObjects = data.data.resultados;
+                        this.items = this.classifyGroupRT(this.rtObjects);
+                    })
+                }
             },
 
             async getCommonAttributes(schema){


### PR DESCRIPTION
Se actualizan las normas de captura para reflejar los cambios en el modelo BDIG/BTN se eliminan todas las referencias a los id de relación en las tablas 0300 se utilizará a partir de ahora el globalid como elemento para relacionar las tablas p y z.

Se actualiza el codigo de la generación del menú de grupos para que refleje automaticamente los cambios en la base de datos y sea capaz de auto organizarse de acuerdo a los temas y codigos.

Se añade un condicional a la hora de generar los temas para no tener que generarlos en cada recarga.